### PR TITLE
Set app theme so that it does not flash the holo theme on pre L devices

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:name=".classes.OpengurApp"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name">
+        android:label="@string/app_name"
+        android:theme="@style/Theme.AppCompat">
         <activity android:name=".activities.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Use Theme.AppCompat so that the app will show just a grey screen when first loading from an unloaded state. If you were to load the app on a pre L device, you would see the old holo actionbar blue theme. 